### PR TITLE
Add corner radius to containerView when extending behind handle

### DIFF
--- a/FittedSheetsPod/SheetViewController.swift
+++ b/FittedSheetsPod/SheetViewController.swift
@@ -193,6 +193,7 @@ public class SheetViewController: UIViewController {
             self.containerHeightConstraint = subview.height.set(self.height(for: self.containerSize))
             self.containerHeightConstraint.priority = UILayoutPriority(900)
         }
+        self.containerView.layer.masksToBounds = true
         self.containerView.backgroundColor = UIColor.clear
         self.containerView.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height)
         
@@ -242,8 +243,8 @@ public class SheetViewController: UIViewController {
     /// Updates which view has rounded corners (only supported on iOS 11)
     private func updateRoundedCorners() {
         if #available(iOS 11.0, *) {
-            let controllerWithRoundedCorners = extendBackgroundBehindHandle ? self.pullBarView : self.childViewController.view
-            let controllerWithoutRoundedCorners = extendBackgroundBehindHandle ? self.childViewController.view : self.pullBarView
+            let controllerWithRoundedCorners = extendBackgroundBehindHandle ? self.containerView : self.childViewController.view
+            let controllerWithoutRoundedCorners = extendBackgroundBehindHandle ? self.childViewController.view : self.containerView
             controllerWithRoundedCorners?.layer.maskedCorners = self.topCornersRadius > 0 ? [.layerMaxXMinYCorner, .layerMinXMinYCorner] : []
             controllerWithRoundedCorners?.layer.cornerRadius = self.topCornersRadius
             controllerWithoutRoundedCorners?.layer.maskedCorners = []


### PR DESCRIPTION
Previously when using a large corner radius (> 25) along with `extendBackgroundBehindHandle`, a weird clipping issue would occur because the corner radius was applied to the `pullBarView` which only had a height of 50 pixels (see attached images).

This changes moves the corner radius to the `containerView` when `extendBackgroundBehindHandle` is true, so that both `pullBarView` and the child ViewController's view is clipped.

### Before
![IMG_0066](https://user-images.githubusercontent.com/474564/54153960-383d7880-4417-11e9-839e-0c9515b8e3b5.PNG)
![IMG_0065](https://user-images.githubusercontent.com/474564/54153966-3b386900-4417-11e9-9eb7-ea03de147cb4.PNG)

### After
![IMG_0069](https://user-images.githubusercontent.com/474564/54154148-9cf8d300-4417-11e9-878b-00ee50e27896.PNG)
![IMG_0068](https://user-images.githubusercontent.com/474564/54154154-9ec29680-4417-11e9-816e-08ea0821d1c5.PNG)
