### PR TITLE
Corrected Readme Example Reference Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sheetController.overlayColor = UIColor.red
 // Change the handle color
 sheetController.handleColor = UIColor.orange
 
-self.present(controller, animated: false, completion: nil)
+self.present(sheetController, animated: false, completion: nil)
 ```
 
 **Handling dismiss events**


### PR DESCRIPTION
Readme example references `present(controller, animated: false, completion: nil)` when it should be `present(sheetController, animated: false, completion: nil)` as per example before