### PR TITLE
exclude UIControls in shouldReceive touch

### DIFF
--- a/FittedSheetsPod/SheetViewController.swift
+++ b/FittedSheetsPod/SheetViewController.swift
@@ -454,7 +454,7 @@ extension SheetViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         guard let view = touch.view else { return true }
         // Allowing gesture recognition on a button seems to prevent it's events from firing properly sometimes
-        return !(view is UIButton)
+        return !(view is UIControl)
     }
     
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {


### PR DESCRIPTION
UIButtons are already excluded for the gesture recognizer shouldReceive touch delegate. Could we expand that to all UIControls, since the issues also occur with UISlider for instance