### PR TITLE
Added voiceover tap to dismiss

### DIFF
--- a/FittedSheets/Pod/SheetViewController.swift
+++ b/FittedSheets/Pod/SheetViewController.swift
@@ -219,6 +219,10 @@ public class SheetViewController: UIViewController {
             subview.height.set(24)
         }
         self.pullBarView = pullBarView
+        pullBarView.isAccessibilityElement = true
+        pullBarView.accessibilityLabel = "Pull bar"
+        pullBarView.accessibilityHint = "Tap on this bar to dismiss the modal"
+        pullBarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissTapped)))
         
         let grabView = UIView(frame: CGRect.zero)
         pullBarView.addSubview(grabView) { (subview) in


### PR DESCRIPTION
Previously, VoiceOver users had no ability to exit the sheet. Now anyone can simply tap on the pull bar to dismiss, and it shows up to the reader.