### PR TITLE
Added accessibility to pull bar

### DIFF
--- a/FittedSheets.podspec.json
+++ b/FittedSheets.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FittedSheets",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "summary": "A bottom sheets implementation for iOS apps.",
   "description": "iOS doesn't have a good way to use bottom sheets natively, so this is to bridge the gap with a decent looking implementation.",
   "homepage": "https://github.com/gordontucker/FittedSheets",

--- a/FittedSheetsPod/SheetViewController.swift
+++ b/FittedSheetsPod/SheetViewController.swift
@@ -294,6 +294,11 @@ public class SheetViewController: UIViewController {
         handleView.layer.cornerRadius = handleSize.height / 2.0
         handleView.layer.masksToBounds = true
         handleView.backgroundColor = self.handleColor
+        
+        pullBarView.isAccessibilityElement = true
+        pullBarView.accessibilityLabel = "Pull bar"
+        pullBarView.accessibilityHint = "Tap on this bar to dismiss the modal"
+        pullBarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissTapped)))
     }
     
     @objc func dismissTapped() {


### PR DESCRIPTION
Previously, Voice Over users were not able to exit the modal. Now anyone can exit by tapping on the pull bar, and it shows up to the screen reader