### PR TITLE
Fixing availability for SPM

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/FittedSheetsPod/SheetContentViewController.swift
+++ b/FittedSheetsPod/SheetContentViewController.swift
@@ -9,6 +9,7 @@
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 
+@available(iOS 11.0, tvOS 11.0, *)
 public class SheetContentViewController: UIViewController {
     
     public private(set) var childViewController: UIViewController

--- a/FittedSheetsPod/SheetTransition.swift
+++ b/FittedSheetsPod/SheetTransition.swift
@@ -9,6 +9,7 @@
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 
+@available(iOS 11.0, tvOS 11.0, *)
 public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
     public static var transitionDuration: TimeInterval = 0.3
     

--- a/FittedSheetsPod/SheetViewController.swift
+++ b/FittedSheetsPod/SheetViewController.swift
@@ -9,6 +9,7 @@
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 
+@available(iOS 11.0, tvOS 11.0, *)
 public class SheetViewController: UIViewController {
     public private(set) var options: SheetOptions
     


### PR DESCRIPTION
Despite having specific platforms
```
platforms: [
        .iOS(.v11), .tvOS(.v10), .macOS(.v10_12), .watchOS(.v3)
    ]
```
when adding through SPM the Xcode produces errors related to availability.

This PR fixes this issue.