### PR TITLE
Added spring based animation options to the sheet transition animations

### DIFF
--- a/FittedSheetsPod/SheetOptions.swift
+++ b/FittedSheetsPod/SheetOptions.swift
@@ -17,6 +17,12 @@ public struct SheetOptions {
     public var presentingViewCornerRadius: CGFloat = 12
     public var shouldExtendBackground = true
     public var setIntrensicHeightOnNavigationControllers = true
+
+    public var transitionAnimationOptions: UIView.AnimationOptions = [.curveEaseOut]
+    public var transitionDampening: CGFloat = 0.8
+    public var transitionDuration: TimeInterval = 0.4
+    public var transitionVelocity: CGFloat = 0.75
+
     /// Allow the sheet to become full screen if pulled all the way to the top and not larger than the maximum size specified in sizes. Defaults to false.
     public var useFullScreenMode = true
     public var shrinkPresentingViewController = true

--- a/FittedSheetsPod/SheetTransition.swift
+++ b/FittedSheetsPod/SheetTransition.swift
@@ -10,22 +10,20 @@
 import UIKit
 
 public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
-    public static var transitionDuration: TimeInterval = 0.3
-    
+
     var presenting = true
     weak var presenter: UIViewController?
     var options: SheetOptions
-    var duration = SheetTransition.transitionDuration
-    
+
     init(options: SheetOptions) {
         self.options = options
         super.init()
     }
-    
+
     public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return self.duration
+        return self.options.transitionDuration
     }
-    
+
     public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let containerView = transitionContext.containerView
         if self.presenting {
@@ -44,9 +42,13 @@ public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
             let contentView = sheet.contentViewController.contentView
             contentView.transform = CGAffineTransform(translationX: 0, y: contentView.bounds.height)
             sheet.overlayView.alpha = 0
-            
+
             UIView.animate(
-                withDuration: self.duration,
+                withDuration: self.options.transitionDuration,
+                delay: 0,
+                usingSpringWithDamping: self.options.transitionDampening,
+                initialSpringVelocity: self.options.transitionVelocity,
+                options: self.options.transitionAnimationOptions,
                 animations: {
                     if self.options.shrinkPresentingViewController {
 
@@ -69,10 +71,10 @@ public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
                 transitionContext.completeTransition(true)
                 return
             }
-            
+
             containerView.addSubview(sheet.view)
             let contentView = sheet.contentViewController.contentView
-            
+
             self.restorePresentor(
                 presenter,
                 animations: {
@@ -84,10 +86,14 @@ public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
             )
         }
     }
-    
+
     func restorePresentor(_ presenter: UIViewController, animated: Bool = true, animations: (() -> Void)? = nil, completion: ((Bool) -> Void)? = nil) {
         UIView.animate(
-            withDuration: self.duration,
+            withDuration: self.options.transitionDuration,
+            delay: 0,
+            usingSpringWithDamping: self.options.transitionDampening,
+            initialSpringVelocity: self.options.transitionVelocity,
+            options: self.options.transitionAnimationOptions,
             animations: {
                 if self.options.shrinkPresentingViewController {
                     presenter.view.layer.transform = CATransform3DMakeScale(1, 1, 1)
@@ -100,13 +106,13 @@ public class SheetTransition: NSObject, UIViewControllerAnimatedTransitioning {
             }
         )
     }
-    
+
     func setPresentor(percentComplete: CGFloat) {
         guard self.options.shrinkPresentingViewController, let presenter = self.presenter else { return }
         let scale: CGFloat = min(1, 0.92 + (0.08 * percentComplete))
-        
+
         let topSafeArea = UIApplication.shared.windows.filter {$0.isKeyWindow}.first?.safeAreaInsets.top ?? 0
-        
+
         presenter.view.layer.transform = CATransform3DConcat(CATransform3DMakeTranslation(0, (1 - percentComplete) * topSafeArea/2, 0), CATransform3DMakeScale(scale, scale, 1))
         presenter.view.layer.cornerRadius = self.options.presentingViewCornerRadius * (1 - percentComplete)
     }

--- a/FittedSheetsPod/SheetViewController.swift
+++ b/FittedSheetsPod/SheetViewController.swift
@@ -417,7 +417,13 @@ public class SheetViewController: UIViewController {
                 
                 guard finalHeight > 0 || !self.dismissOnPull else {
                     // Dismiss
-                    UIView.animate(withDuration: animationDuration, delay: 0, options: [.curveEaseOut], animations: {
+                    UIView.animate(
+                        withDuration: animationDuration,
+                        delay: 0,
+                        usingSpringWithDamping: self.options.transitionDampening,
+                        initialSpringVelocity: self.options.transitionVelocity,
+                        options: self.options.transitionAnimationOptions,
+                        animations: {
                         self.contentViewController.view.transform = CGAffineTransform(translationX: 0, y: self.contentViewController.view.bounds.height)
                         self.view.backgroundColor = UIColor.clear
                         self.transition.setPresentor(percentComplete: 1)
@@ -454,7 +460,13 @@ public class SheetViewController: UIViewController {
                 self.currentSize = newSize
                 
                 let newContentHeight = self.height(for: newSize)
-                UIView.animate(withDuration: animationDuration, delay: 0, options: [.curveEaseOut], animations: {
+                UIView.animate(
+                    withDuration: animationDuration,
+                    delay: 0,
+                    usingSpringWithDamping: self.options.transitionDampening,
+                    initialSpringVelocity: self.options.transitionVelocity,
+                    options: self.options.transitionAnimationOptions,
+                    animations: {
                     self.contentViewController.view.transform = CGAffineTransform.identity
                     self.contentViewHeightConstraint.constant = newContentHeight
                     self.transition.setPresentor(percentComplete: 0)


### PR DESCRIPTION
These are configurable via the SheetOptions object. I tuned them to be pretty subtle by default, but of course they could also be turned off by default.

If you turn down the dampening, you'll see a design flaw, in that the sheet will bounce up away from the bottom edge of the screen. I couldn't think of an easy way to fix that. With a subtle bounce, I think it looks fine.

In theory, this addresses #6 