### PR TITLE
Setup childForStatusBarStyle

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -54,6 +54,10 @@ public class SheetViewController: UIViewController {
     public var childViewController: UIViewController {
         return self.contentViewController.childViewController
     }
+
+    public override var childForStatusBarStyle: UIViewController? {
+        childViewController
+    }
     
     public static var hasBlurBackground = false
     public var hasBlurBackground = SheetViewController.hasBlurBackground {


### PR DESCRIPTION
In order to provide a custom statusBar style (useful/ required when presenting the sheet only partially) we have to override `childForStatusBarStyle`