### PR TITLE
Covers NavigationBar when using inline mode

### DIFF
--- a/Demos/Base.lproj/Main.storyboard
+++ b/Demos/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Km3-vg-lm2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Km3-vg-lm2">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="4352" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController storyboardIdentifier="examples" id="PeH-a5-9HN" customClass="ModalDemosViewController" customModule="Demos" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="bDC-zY-nqc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E5b-WP-7ZL">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="21S-uT-Rwi">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -72,11 +72,11 @@
             <objects>
                 <viewController id="tGk-6I-1Oe" customClass="InlineDemosViewController" customModule="Demos" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="CcI-q1-73M">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SPD-Z7-4Ev">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                                 <subviews>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i9m-pZ-Mzl">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
@@ -143,14 +143,14 @@
             <objects>
                 <viewController id="uXn-Co-RxK" customClass="MapViewController" customModule="Demos" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3fm-RZ-aK4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LIu-Ve-lKX">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="map" translatesAutoresizingMaskIntoConstraints="NO" id="eYC-aP-95U">
-                                        <rect key="frame" x="0.0" y="0.0" width="562.5" height="1000.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="562.5" height="934.5"/>
                                     </imageView>
                                 </subviews>
                                 <constraints>
@@ -163,7 +163,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="4za-ga-6Oq"/>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FkR-KE-QsB">
-                                <rect key="frame" x="20" y="603" width="335" height="44"/>
+                                <rect key="frame" x="20" y="559" width="335" height="44"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="eLR-AV-pNs"/>
@@ -205,7 +205,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Km3-vg-lm2" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Xl9-fl-n0d">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="Xl9-fl-n0d">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -223,11 +223,11 @@
             <objects>
                 <viewController id="qVL-px-S5p" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jIs-bd-8Gc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="L4d-Cx-FWH">
-                                <rect key="frame" x="20" y="64" width="335" height="212"/>
+                                <rect key="frame" x="20" y="20" width="335" height="212"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sUi-wz-rpu">
                                         <rect key="frame" x="0.0" y="0.0" width="335" height="44"/>
@@ -303,11 +303,11 @@
             <objects>
                 <viewController id="vr4-km-JLX" customClass="BugVerificationsViewController" customModule="Demos" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F90-00-VFT">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gpr-FL-kmi">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="50H-2E-n4o">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>

--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -20,7 +20,7 @@ public struct SheetOptions {
     }
     
     public var pullBarHeight: CGFloat = 24
-    public var navBarHeight: CGFloat? = nil
+    
     public var presentingViewCornerRadius: CGFloat = 12
     public var shouldExtendBackground = true
     public var setIntrinsicHeightOnNavigationControllers = true
@@ -40,7 +40,6 @@ public struct SheetOptions {
     
     public var horizontalPadding: CGFloat = 0
     public var maxWidth: CGFloat?
-    public var useSecondOverlay = true
     
     /* These properties will be removed in an upcoming release, leaving them for now so people can transition slowly */
     
@@ -68,9 +67,7 @@ public struct SheetOptions {
                 shrinkPresentingViewController: Bool? = nil,
                 useInlineMode: Bool? = nil,
                 horizontalPadding: CGFloat? = nil,
-                maxWidth: CGFloat? = nil,
-                navBarHeight: CGFloat? = nil,
-                useSecondOverlay: Bool = true) {
+                maxWidth: CGFloat? = nil) {
         let defaultOptions = SheetOptions.default
         self.pullBarHeight = pullBarHeight ?? defaultOptions.pullBarHeight
         self.presentingViewCornerRadius = presentingViewCornerRadius ?? defaultOptions.presentingViewCornerRadius
@@ -82,8 +79,6 @@ public struct SheetOptions {
         self.horizontalPadding = horizontalPadding ?? defaultOptions.horizontalPadding
         let maxWidth = maxWidth ?? defaultOptions.maxWidth
         self.maxWidth = maxWidth == 0 ? nil : maxWidth
-        self.navBarHeight = navBarHeight
-        self.useSecondOverlay = useSecondOverlay
     }
     
     @available(*, unavailable, message: "cornerRadius, minimumSpaceAbovePullBar, gripSize and gripColor are now properties on SheetViewController. Use them instead.")

--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -40,6 +40,7 @@ public struct SheetOptions {
     
     public var horizontalPadding: CGFloat = 0
     public var maxWidth: CGFloat?
+    public var useSecondOverlay = true
     
     /* These properties will be removed in an upcoming release, leaving them for now so people can transition slowly */
     
@@ -68,7 +69,8 @@ public struct SheetOptions {
                 useInlineMode: Bool? = nil,
                 horizontalPadding: CGFloat? = nil,
                 maxWidth: CGFloat? = nil,
-                navBarHeight: CGFloat? = nil) {
+                navBarHeight: CGFloat? = nil,
+                useSecondOverlay: Bool = true) {
         let defaultOptions = SheetOptions.default
         self.pullBarHeight = pullBarHeight ?? defaultOptions.pullBarHeight
         self.presentingViewCornerRadius = presentingViewCornerRadius ?? defaultOptions.presentingViewCornerRadius
@@ -81,6 +83,7 @@ public struct SheetOptions {
         let maxWidth = maxWidth ?? defaultOptions.maxWidth
         self.maxWidth = maxWidth == 0 ? nil : maxWidth
         self.navBarHeight = navBarHeight
+        self.useSecondOverlay = useSecondOverlay
     }
     
     @available(*, unavailable, message: "cornerRadius, minimumSpaceAbovePullBar, gripSize and gripColor are now properties on SheetViewController. Use them instead.")

--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -20,7 +20,7 @@ public struct SheetOptions {
     }
     
     public var pullBarHeight: CGFloat = 24
-    
+    public var navBarHeight: CGFloat? = nil
     public var presentingViewCornerRadius: CGFloat = 12
     public var shouldExtendBackground = true
     public var setIntrinsicHeightOnNavigationControllers = true
@@ -67,7 +67,8 @@ public struct SheetOptions {
                 shrinkPresentingViewController: Bool? = nil,
                 useInlineMode: Bool? = nil,
                 horizontalPadding: CGFloat? = nil,
-                maxWidth: CGFloat? = nil) {
+                maxWidth: CGFloat? = nil,
+                navBarHeight: CGFloat? = nil) {
         let defaultOptions = SheetOptions.default
         self.pullBarHeight = pullBarHeight ?? defaultOptions.pullBarHeight
         self.presentingViewCornerRadius = presentingViewCornerRadius ?? defaultOptions.presentingViewCornerRadius
@@ -79,6 +80,7 @@ public struct SheetOptions {
         self.horizontalPadding = horizontalPadding ?? defaultOptions.horizontalPadding
         let maxWidth = maxWidth ?? defaultOptions.maxWidth
         self.maxWidth = maxWidth == 0 ? nil : maxWidth
+        self.navBarHeight = navBarHeight
     }
     
     @available(*, unavailable, message: "cornerRadius, minimumSpaceAbovePullBar, gripSize and gripColor are now properties on SheetViewController. Use them instead.")

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -224,6 +224,7 @@ public class SheetViewController: UIViewController {
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        self.overlayView.removeFromSuperview()
         if let presenter = self.transition.presenter, self.options.shrinkPresentingViewController {
             self.transition.restorePresentor(presenter, completion: { _ in
                 self.didDismiss?(self)
@@ -274,7 +275,7 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        self.view.addSubview(self.overlayView)
+        UIApplication.shared.keyWindow?.addSubview(overlayView)
         Constraints(for: self.overlayView) {
             $0.edges(.top, .left, .right, .bottom).pinToSuperview()
         }

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -291,9 +291,9 @@ public class SheetViewController: UIViewController {
     private func addOverlay() {
         if let nav = self.parentVC?.navigationController {
             var frame = nav.navigationBar.frame
-            if frame.origin.y > 0 {
+            if frame.origin.y != 0 {
                 // covers status bar
-                frame = CGRect(x: frame.origin.x, y: 0, width: frame.size.width, height: frame.size.height + frame.origin.y)
+                frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: frame.size.height + abs(frame.origin.y))
             }
 
             secondOverlayView = UIView(frame: frame)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -293,7 +293,8 @@ public class SheetViewController: UIViewController {
             var frame = nav.navigationBar.frame
             if frame.origin.y != 0 {
                 // covers status bar
-                frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: frame.size.height + abs(frame.origin.y))
+                frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width,
+                               height: frame.size.height + abs(frame.origin.y) + UIApplication.shared.statusBarFrame.height)
             }
 
             secondOverlayView = UIView(frame: frame)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -292,7 +292,10 @@ public class SheetViewController: UIViewController {
         if let nav = self.parentVC?.navigationController {
             var frame = nav.navigationBar.frame
             if frame.origin.y != 0 {
-                frame = CGRect(x: frame.origin.x, y: 0, width: frame.size.width, height: frame.size.height + UIApplication.shared.statusBarFrame.height)
+                frame = CGRect(x: frame.origin.x,
+                               y: 0,
+                               width: frame.size.width,
+                               height: (options.navBarHeight ?? frame.size.height) + UIApplication.shared.statusBarFrame.height)
             }
 
             secondOverlayView = UIView(frame: frame)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -205,27 +205,23 @@ public class SheetViewController: UIViewController {
         self.additionalSafeAreaInsets = UIEdgeInsets(top: -self.options.pullBarHeight, left: 0, bottom: 0, right: 0)
         
         self.view.backgroundColor = UIColor.clear
+        self.addPanGestureRecognizer()
         if !options.useInlineMode {
-            self.addPanGestureRecognizer()
             self.addOverlay()
             self.addBlurBackground()
-            self.addContentView()
-            self.addOverlayTapView()
-            self.registerKeyboardObservers()
-            self.resize(to: self.sizes.first ?? .intrinsic, animated: false)
         }
+        self.addContentView()
+        self.addOverlayTapView()
+        self.registerKeyboardObservers()
+        self.resize(to: self.sizes.first ?? .intrinsic, animated: false)
     }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         if options.useInlineMode {
-            self.addPanGestureRecognizer()
             self.addOverlay()
             self.addBlurBackground()
-            self.addContentView()
-            self.addOverlayTapView()
-            self.registerKeyboardObservers()
         }
         self.updateOrderedSizes()
         self.contentViewController.updatePreferredHeight()

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -206,10 +206,8 @@ public class SheetViewController: UIViewController {
         
         self.view.backgroundColor = UIColor.clear
         self.addPanGestureRecognizer()
-        if !options.useInlineMode {
-            self.addOverlay()
-            self.addBlurBackground()
-        }
+        self.addOverlay()
+        self.addBlurBackground()
         self.addContentView()
         self.addOverlayTapView()
         self.registerKeyboardObservers()
@@ -221,7 +219,6 @@ public class SheetViewController: UIViewController {
         
         if options.useInlineMode {
             self.addOverlay()
-            self.addBlurBackground()
         }
         self.updateOrderedSizes()
         self.contentViewController.updatePreferredHeight()
@@ -285,14 +282,17 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        self.view.addSubview(self.overlayView)
-        Constraints(for: self.overlayView) {
-            $0.edges(.top, .left, .right, .bottom).pinToSuperview()
+        if self.overlayView.superview == nil {
+            self.view.addSubview(self.overlayView)
+            Constraints(for: self.overlayView) {
+                $0.edges(.top, .left, .right, .bottom).pinToSuperview()
+            }
+            self.overlayView.isUserInteractionEnabled = false
+            self.overlayView.backgroundColor = self.hasBlurBackground ? .clear : self.overlayColor
         }
-        self.overlayView.isUserInteractionEnabled = false
-        self.overlayView.backgroundColor = self.hasBlurBackground ? .clear : self.overlayColor
         
         if let nav = self.parentVC?.navigationController, let parentView = self.parentVC?.view {
+            secondOverlayView?.removeFromSuperview()
             let viewRect = parentView.convert(parentView.bounds, to: nil)
             secondOverlayView = UIView(frame: CGRect(x: 0, y: 0, width: viewRect.width, height: viewRect.origin.y))
             nav.view.addSubview(secondOverlayView!)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -292,9 +292,7 @@ public class SheetViewController: UIViewController {
         if let nav = self.parentVC?.navigationController {
             var frame = nav.navigationBar.frame
             if frame.origin.y != 0 {
-                // covers status bar
-                frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width,
-                               height: frame.size.height + abs(frame.origin.y) + UIApplication.shared.statusBarFrame.height)
+                frame = CGRect(x: frame.origin.x, y: 0, width: frame.size.width, height: frame.size.height + UIApplication.shared.statusBarFrame.height)
             }
 
             secondOverlayView = UIView(frame: frame)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -275,10 +275,11 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        if let nav = self.parent?.navigationController else {
+        if let nav = self.parent?.navigationController {
             nav.view.addSubview(overlayView)
+        } else {
+            parent?.view.addSubview(overlayView)
         }
-        parent?.view.addSubview(overlayView)
 
         Constraints(for: self.overlayView) {
             $0.edges(.top, .left, .right, .bottom).pinToSuperview()

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -275,7 +275,11 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        UIApplication.shared.keyWindow?.addSubview(overlayView)
+        if let nav = self.parent?.navigationController else {
+            nav.view.addSubview(overlayView)
+        }
+        parent?.view.addSubview(overlayView)
+
         Constraints(for: self.overlayView) {
             $0.edges(.top, .left, .right, .bottom).pinToSuperview()
         }

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -289,7 +289,7 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        if let nav = self.parentVC?.navigationController {
+        if let nav = self.parentVC?.navigationController, options.useSecondOverlay {
             var frame = nav.navigationBar.frame
             if frame.origin.y != 0 {
                 frame = CGRect(x: frame.origin.x,

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -289,26 +289,19 @@ public class SheetViewController: UIViewController {
     }
     
     private func addOverlay() {
-        if let nav = self.parentVC?.navigationController, options.useSecondOverlay {
-            var frame = nav.navigationBar.frame
-            if frame.origin.y != 0 {
-                frame = CGRect(x: frame.origin.x,
-                               y: 0,
-                               width: frame.size.width,
-                               height: (options.navBarHeight ?? frame.size.height) + UIApplication.shared.statusBarFrame.height)
-            }
-
-            secondOverlayView = UIView(frame: frame)
-            nav.view.addSubview(secondOverlayView!)
-            secondOverlayView?.backgroundColor = self.hasBlurBackground ? .clear : self.overlayColor
-        }
-        
         self.view.addSubview(self.overlayView)
         Constraints(for: self.overlayView) {
             $0.edges(.top, .left, .right, .bottom).pinToSuperview()
         }
         self.overlayView.isUserInteractionEnabled = false
         self.overlayView.backgroundColor = self.hasBlurBackground ? .clear : self.overlayColor
+        
+        if let nav = self.parentVC?.navigationController, let parentView = self.parentVC?.view {
+            let viewRect = parentView.convert(parentView.bounds, to: nil)
+            secondOverlayView = UIView(frame: CGRect(x: 0, y: 0, width: viewRect.width, height: viewRect.origin.y))
+            nav.view.addSubview(secondOverlayView!)
+            secondOverlayView?.backgroundColor = self.hasBlurBackground ? .clear : self.overlayColor
+        }
     }
     
     private func addBlurBackground() {

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -205,17 +205,28 @@ public class SheetViewController: UIViewController {
         self.additionalSafeAreaInsets = UIEdgeInsets(top: -self.options.pullBarHeight, left: 0, bottom: 0, right: 0)
         
         self.view.backgroundColor = UIColor.clear
+        if !options.useInlineMode {
+            self.addPanGestureRecognizer()
+            self.addOverlay()
+            self.addBlurBackground()
+            self.addContentView()
+            self.addOverlayTapView()
+            self.registerKeyboardObservers()
+            self.resize(to: self.sizes.first ?? .intrinsic, animated: false)
+        }
     }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.addPanGestureRecognizer()
-        self.addOverlay()
-        self.addBlurBackground()
-        self.addContentView()
-        self.addOverlayTapView()
-        self.registerKeyboardObservers()
+        if options.useInlineMode {
+            self.addPanGestureRecognizer()
+            self.addOverlay()
+            self.addBlurBackground()
+            self.addContentView()
+            self.addOverlayTapView()
+            self.registerKeyboardObservers()
+        }
         self.updateOrderedSizes()
         self.contentViewController.updatePreferredHeight()
         self.resize(to: self.currentSize, animated: false)


### PR DESCRIPTION
I realized that by default,  the navigation bar isn't covered by the overlay when using inline mode options.

This PR resolves that issue by checking if sheet is presented from a NavigationController and add a secondary overlay on top of the navigation controller.

I was thinking to restructure the overlay and whole content to the top of navigation controller, but that does not work as the concept of the overlay is to use the view contained by the parent VC to resolves the constraints and sizes.
I know this is a bit (maybe very) hack-y way to do things.

before:
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-30 at 23 51 26](https://user-images.githubusercontent.com/7204143/127765415-0b47db9b-1533-4cec-b1f6-ae226758c8f8.png)

after:
![simulator_screenshot_DDBECA86-7E6C-453E-BCB9-F2FF6A901B8A](https://user-images.githubusercontent.com/7204143/127765417-4a82d6d4-97de-4637-9106-3c754081f744.png)