### PR TITLE
Fixes #118

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -556,7 +556,7 @@ public class SheetViewController: UIViewController {
             UIView.animate(withDuration: duration, delay: 0, options: options, animations: { [weak self] in
                 guard let self = self, let constraint = self.contentViewHeightConstraint else { return }
                 constraint.constant = newHeight
-                self.view.layoutIfNeeded()
+                self.contentViewController.view.layoutIfNeeded()
             }, completion: { _ in
                 if previousSize != size {
                     self.sizeChanged?(self, size, newHeight)


### PR DESCRIPTION
Superview constraint are being animated when the resize function is setting the contentViewControllerHeightConstraint. With this commit i am able to remove the 'weird sweeping issue' but i think the we can work more on the animation.

how to reproduce:
1. Create child viewcontroller that have collection/tableview inside it.
2. Present the sheetViewController using present() from view controller.