### PR TITLE
Add support for choosing the corner curve

### DIFF
--- a/FittedSheets/SheetContentViewController.swift
+++ b/FittedSheets/SheetContentViewController.swift
@@ -22,7 +22,8 @@ public class SheetContentViewController: UIViewController {
         set { self.childContainerView.backgroundColor = newValue }
     }
 
-    public var cornerCurve: CALayerCornerCurve = .circular {
+    @available(iOS 13.0, *)
+    public lazy var cornerCurve: CALayerCornerCurve = .circular {
         didSet {
             self.updateCornerCurve()
         }
@@ -97,7 +98,9 @@ public class SheetContentViewController: UIViewController {
         self.setupPullBarView()
         self.setupChildViewController()
         self.updatePreferredHeight()
-        self.updateCornerCurve()
+        if #available(iOS 13.0, *) {
+            self.updateCornerCurve()
+        }
         self.updateCornerRadius()
         self.setupOverflowView()
     }
@@ -129,6 +132,7 @@ public class SheetContentViewController: UIViewController {
         self.updateChildViewControllerBottomConstraint(adjustment: -height)
     }
 
+    @available(iOS 13.0, *)
     private func updateCornerCurve() {
         self.contentWrapperView.layer.cornerCurve = self.cornerCurve
         self.childContainerView.layer.cornerCurve = self.cornerCurve

--- a/FittedSheets/SheetContentViewController.swift
+++ b/FittedSheets/SheetContentViewController.swift
@@ -21,6 +21,12 @@ public class SheetContentViewController: UIViewController {
         get { self.childContainerView.backgroundColor }
         set { self.childContainerView.backgroundColor = newValue }
     }
+
+    public var cornerCurve: CALayerCornerCurve = .circular {
+        didSet {
+            self.updateCornerCurve()
+        }
+    }
     
     public var cornerRadius: CGFloat = 0 {
         didSet {
@@ -91,6 +97,7 @@ public class SheetContentViewController: UIViewController {
         self.setupPullBarView()
         self.setupChildViewController()
         self.updatePreferredHeight()
+        self.updateCornerCurve()
         self.updateCornerRadius()
         self.setupOverflowView()
     }
@@ -121,7 +128,12 @@ public class SheetContentViewController: UIViewController {
     func adjustForKeyboard(height: CGFloat) {
         self.updateChildViewControllerBottomConstraint(adjustment: -height)
     }
-    
+
+    private func updateCornerCurve() {
+        self.contentWrapperView.layer.cornerCurve = self.cornerCurve
+        self.childContainerView.layer.cornerCurve = self.cornerCurve
+    }
+
     private func updateCornerRadius() {
         self.contentWrapperView.layer.cornerRadius = self.treatPullBarAsClear ? 0 : self.cornerRadius
         self.childContainerView.layer.cornerRadius = self.treatPullBarAsClear ? self.cornerRadius : 0

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -106,6 +106,12 @@ public class SheetViewController: UIViewController {
         get { return self.contentViewController.cornerRadius }
         set { self.contentViewController.cornerRadius = newValue }
     }
+
+    public static var cornerCurve: CALayerCornerCurve = .circular
+    public var cornerCurve: CALayerCornerCurve {
+        get { return self.contentViewController.cornerCurve }
+        set { self.contentViewController.cornerCurve = newValue }
+    }
     
     public static var gripSize: CGSize = CGSize (width: 50, height: 6)
     public var gripSize: CGSize {

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -107,7 +107,10 @@ public class SheetViewController: UIViewController {
         set { self.contentViewController.cornerRadius = newValue }
     }
 
+    @available(iOS 13.0, *)
     public static var cornerCurve: CALayerCornerCurve = .circular
+
+    @available(iOS 13.0, *)
     public var cornerCurve: CALayerCornerCurve {
         get { return self.contentViewController.cornerCurve }
         set { self.contentViewController.cornerCurve = newValue }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ sheetController.gripSize = CGSize(width: 50, height: 6)
 // The color of the grip on the pull bar
 sheetController.gripColor = UIColor(white: 0.868, alpha: 1)
 
+// The corner curve of the sheet
+sheetController.cornerCurve = .continuous
+
 // The corner radius of the sheet
 sheetController.cornerRadius = 20
     

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sheetController.gripSize = CGSize(width: 50, height: 6)
 // The color of the grip on the pull bar
 sheetController.gripColor = UIColor(white: 0.868, alpha: 1)
 
-// The corner curve of the sheet
+// The corner curve of the sheet (iOS 13 or later)
 sheetController.cornerCurve = .continuous
 
 // The corner radius of the sheet


### PR DESCRIPTION
- Currently, only circular corner curves are possible
- This adds support for choosing the corner curve to be continuous if desired
- Support is limited to iOS 13 or later

This was previously #160. See comments there for context on the CI failure.