### PR TITLE
Option to allow override should begin pull gesture

### DIFF
--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -32,6 +32,9 @@ public struct SheetOptions {
     public var transitionVelocity: CGFloat = 0.8
     public var transitionOverflowType: TransitionOverflowType = .automatic
     
+    /// Default value 500, greater value will require more velocity to dismiss. Lesser values will do opposite.
+    public var pullDismissThreshod: CGFloat = 500.0
+    
     /// Allow the sheet to become full screen if pulled all the way to the top and not larger than the maximum size specified in sizes. Defaults to false.
     public var useFullScreenMode = true
     public var shrinkPresentingViewController = true

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -136,6 +136,7 @@ public class SheetViewController: UIViewController {
     public var shouldDismiss: ((SheetViewController) -> Bool)?
     public var didDismiss: ((SheetViewController) -> Void)?
     public var sizeChanged: ((SheetViewController, SheetSize, CGFloat) -> Void)?
+    public var panGestureShouldBegin: ((UIPanGestureRecognizer) -> Bool?)?
     
     public private(set) var contentViewController: SheetContentViewController
     var overlayView = UIView()
@@ -690,6 +691,10 @@ extension SheetViewController: UIGestureRecognizerDelegate {
     
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let panGestureRecognizer = gestureRecognizer as? InitialTouchPanGestureRecognizer, let childScrollView = self.childScrollView, let point = panGestureRecognizer.initialTouchLocation else { return true }
+        
+        if let pan = gestureRecognizer as? UIPanGestureRecognizer, let closure = panGestureShouldBegin, let should = closure(pan) {
+            return should
+        }
         
         let pointInChildScrollView = self.view.convert(point, to: childScrollView).y - childScrollView.contentOffset.y
         

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -402,7 +402,7 @@ public class SheetViewController: UIViewController {
             case .ended:
                 let velocity = (0.2 * gesture.velocity(in: self.view).y)
                 var finalHeight = newHeight - offset - velocity
-                if velocity > 500 {
+                if velocity > options.pullDismissThreshod {
                     // They swiped hard, always just close the sheet when they do
                     finalHeight = -1
                 }


### PR DESCRIPTION
Option to allow override should begin pull gesture. This is needed when we have a header and scroll view is not scrolled top.