### PR TITLE
Add supportedInterfaceOrientations

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -58,6 +58,10 @@ public class SheetViewController: UIViewController {
     public override var childForStatusBarStyle: UIViewController? {
         childViewController
     }
+	
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return childViewController.supportedInterfaceOrientations
+    }
     
     public static var hasBlurBackground = false
     public var hasBlurBackground = SheetViewController.hasBlurBackground {


### PR DESCRIPTION
Hello there. In my app some screen supporting different interface orientation like:

```Swift
override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return UIDevice.current.userInterfaceIdiom == .pad ? .all : [.portrait, .portraitUpsideDown]
 }
```

So I faced with a problem that `SheetViewController` ignoring `supportedInterfaceOrientations` of a child

I thinks that should be fair enough if `SheetViewController` could inherit supported interface orientations of his child