### PR TITLE
dismissOnPull obeys shouldDismiss

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -427,7 +427,7 @@ public class SheetViewController: UIViewController {
                 
                 let animationDuration = TimeInterval(abs(velocity*0.0002) + 0.2)
                 
-                guard finalHeight > 0 || !self.dismissOnPull else {
+                guard finalHeight > 0 || !(self.dismissOnPull && self.shouldDismiss?(self) ?? true) else {
                     // Dismiss
                     UIView.animate(
                         withDuration: animationDuration,


### PR DESCRIPTION
If you say `vc.dismissOnPull = true` and `vc.shouldDismiss { _ in false }`, I expect the view controller _not_ to be dismissed when I pull down. (This logic applies to `dismissOnOverlayTap` already.)

This change makes that true. Before, the view controller would be hidden even if `shouldDismiss` returned `false`.