### PR TITLE
Add Bug Verification for presenting a fullscreen modal

### DIFF
--- a/Demos/BugVerificationControllers/PresentFullscreenModalCausesDidDismiss.swift
+++ b/Demos/BugVerificationControllers/PresentFullscreenModalCausesDidDismiss.swift
@@ -1,0 +1,49 @@
+//
+//  PresentSecondModal.swift
+//  Demos
+//
+//  Created by Andrew Breckenridge on 5/9/23.
+//  Copyright © 2023 Gordon Tucker. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import FittedSheets
+
+class PresentFullscreenModalCausesDidDismiss: UIViewController, Demoable {
+    static var name: String { "presenting a further view controller with `modalPresentationStyle` of `crossDissolve` causes incorrect `didDismiss` on the sheet" }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+            let controller2 = UIStoryboard(name: "IntrinsicAndFullscreenDemo", bundle: nil).instantiateInitialViewController()!
+            controller2.modalPresentationStyle = .fullScreen // <- CAUSES UNDEFINED BEHAVIOR
+            self.present(controller2, animated: true)
+        }
+    }
+
+    static func openDemo(from parent: UIViewController, in view: UIView?) {
+        let useInlineMode = view != nil
+
+        let controller = PresentFullscreenModalCausesDidDismiss()
+
+        let options = SheetOptions(
+            useFullScreenMode: false,
+            useInlineMode: useInlineMode)
+        let sheet = SheetViewController(controller: controller, sizes: [.fullscreen, .intrinsic], options: options)
+        sheet.minimumSpaceAbovePullBar = 44
+        sheet.didDismiss = { _ in
+            fatalError("shouldn't dismiss when you present the second view")
+        }
+
+        addSheetEventLogging(to: sheet)
+
+        if let view = view {
+            sheet.animateIn(to: view, in: parent)
+        } else {
+            parent.present(sheet, animated: true, completion: nil)
+        }
+    }
+}
+

--- a/Demos/BugVerificationsViewController.swift
+++ b/Demos/BugVerificationsViewController.swift
@@ -18,6 +18,7 @@ class BugVerificationsViewController: UIViewController {
         super.viewDidLoad()
         
         self.addButton(for: SlideInAnimationBug118ViewController.self)
+        self.addButton(for: PresentFullscreenModalCausesDidDismiss.self)
     }
     
     func addButton(for demo: (UIViewController & Demoable).Type, onTap: (() -> Void)? = nil) {

--- a/FittedSheets.xcodeproj/project.pbxproj
+++ b/FittedSheets.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0D18902926C015F700CB6790 /* RubberBandDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18902826C015F700CB6790 /* RubberBandDemo.swift */; };
 		42F0967527040EE7009774EA /* Compatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F0967427040EE7009774EA /* Compatible.swift */; };
+		46E78D7A2A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E78D792A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift */; };
 		C4E231E524E55E4E00D367FD /* BlurDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E231E424E55E4E00D367FD /* BlurDemo.swift */; };
 		D9C73C1F290B2BDF002590EC /* CornerCurveDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C73C1E290B2BDF002590EC /* CornerCurveDemo.swift */; };
 		F8034165212625DD00EAD717 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8034164212625DD00EAD717 /* AppDelegate.swift */; };
@@ -105,6 +106,7 @@
 		0D18902826C015F700CB6790 /* RubberBandDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubberBandDemo.swift; sourceTree = "<group>"; };
 		42F0967427040EE7009774EA /* Compatible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compatible.swift; sourceTree = "<group>"; };
 		46334410249C041700F334E5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		46E78D792A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentFullscreenModalCausesDidDismiss.swift; sourceTree = "<group>"; };
 		C4E231E424E55E4E00D367FD /* BlurDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurDemo.swift; sourceTree = "<group>"; };
 		D9C73C1E290B2BDF002590EC /* CornerCurveDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerCurveDemo.swift; sourceTree = "<group>"; };
 		F8034161212625DD00EAD717 /* Demos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demos.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -242,6 +244,7 @@
 			isa = PBXGroup;
 			children = (
 				F83058F725BF774100EE17E1 /* SlideInAnimationBug118 */,
+				46E78D792A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift */,
 			);
 			path = BugVerificationControllers;
 			sourceTree = "<group>";
@@ -464,6 +467,7 @@
 				F8A42B8D24DB24F9005DE55B /* Yalta.swift in Sources */,
 				F83058FC25BF777400EE17E1 /* SlideInAnimationBug118ViewController.swift in Sources */,
 				F857D0B22204D761004C862F /* ScrollViewDemo.swift in Sources */,
+				46E78D7A2A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift in Sources */,
 				F8799C9325BF5B230095F24F /* ScrollInNavigationDemo.swift in Sources */,
 				F8A42B5A24D36893005DE55B /* ModalDemosViewController.swift in Sources */,
 				F857D0A72204B856004C862F /* SimpleDemo.swift in Sources */,


### PR DESCRIPTION
after presenting the sheet, in the content view, when presenting a further view controller using the `modalTransitionStyle` of `.crossDissolve` causes `sheet.didDismiss` to erroneously fire.
any other modalTransitionStyle doesn't have this behavior.

for now, i'm working around by keeping around a flag before i present the child view controller, but i'd like to better understand this and solve it