### PR TITLE
SheetViewController.swift --> resize animation fix

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -582,7 +582,7 @@ public class SheetViewController: UIViewController {
             UIView.animate(withDuration: duration, delay: 0, options: options, animations: { [weak self] in
                 guard let self = self, let constraint = self.contentViewHeightConstraint else { return }
                 constraint.constant = newHeight
-                self.contentViewController.view.layoutIfNeeded()
+                self.view.layoutIfNeeded()
             }, completion: { _ in
                 if previousSize != size {
                     self.sizeChanged?(self, size, newHeight)


### PR DESCRIPTION
Hi! 

**Problem**
When I resize the FittedSheets with animation and push viewController at the same time - animation do not working. 

**Fix**
I resolved it when changed 
`self.contentViewController.view.layoutIfNeeded()` to `self.view.layoutIfNeeded()`

Thank you for the greate lib! 