### PR TITLE
Add ability to disable ending editing on resize

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -63,6 +63,8 @@ public class SheetViewController: UIViewController {
         return childViewController.supportedInterfaceOrientations
     }
     
+    public var mayEndEditingOnResize = true
+
     public static var hasBlurBackground = false
     public var hasBlurBackground = SheetViewController.hasBlurBackground {
         didSet {
@@ -725,7 +727,7 @@ extension SheetViewController: UIGestureRecognizerDelegate {
         
         let velocity = panGestureRecognizer.velocity(in: panGestureRecognizer.view?.superview)
         guard pointInChildScrollView > 0, pointInChildScrollView < childScrollView.bounds.height else {
-            if keyboardHeight > 0 {
+            if keyboardHeight > 0 && mayEndEditingOnResize {
                 childScrollView.endEditing(true)
             }
             return true


### PR DESCRIPTION
I'm working on a comment editor which presents as a persistent bottom sheet. I was finding that when I drag between detents, my text field was being forced to resign its responder, which is bad. There was also a visual bug where the sheet would be the wrong height during the drag due to its offsets being computed with the keyboard up.

Rather than removing the behavior for all users, I added a config option, but I'm not convinced it's better than simply removing the call to `endEditing()`. It would be better to have some kind of configurable callback so users can choose to end editing if it makes sense for their use case. What do you think?

This line was added a [very long time ago](https://github.com/gordontucker/FittedSheets/commit/caa46b025ccdd37e313460f0a5e7835ae957761f), maybe you have some context you can share @gordontucker?