### PR TITLE
Add support for snapping to closest sheet size

### DIFF
--- a/Demos/DemoControllers/SnapToClosestSheetSizeDemo.swift
+++ b/Demos/DemoControllers/SnapToClosestSheetSizeDemo.swift
@@ -1,0 +1,39 @@
+//
+//  SnapToClosestSheetSizeDemo.swift
+//  Demos
+//
+//  Created by Andrei Tich on 1/30/25.
+//  MIT License
+//
+
+import UIKit
+import FittedSheets
+
+class SnapToClosestSheetSizeDemo: SimpleDemo {
+    override class var name: String { "Snap to closest sheet size" }
+
+    override class func openDemo(from parent: UIViewController, in view: UIView?) {
+        let useInlineMode = view != nil
+
+        let controller = ColorDemo()
+        let options = SheetOptions(
+            useInlineMode: useInlineMode,
+            shouldSnapToClosestSheetSize: true)
+
+
+        let sheet = SheetViewController(
+            controller: controller,
+            sizes: [.percent(0.3), .percent(0.60), .fullscreen],
+            options: options)
+        sheet.allowPullingPastMaxHeight = false
+        sheet.allowPullingPastMinHeight = false
+
+        addSheetEventLogging(to: sheet)
+
+        if let view = view {
+            sheet.animateIn(to: view, in: parent)
+        } else {
+            parent.present(sheet, animated: true, completion: nil)
+        }
+    }
+}

--- a/Demos/InlineDemosViewController.swift
+++ b/Demos/InlineDemosViewController.swift
@@ -35,7 +35,8 @@ class InlineDemosViewController: UIViewController {
         HorizontalPaddingDemo.self,
         MaxWidthDemo.self,
         BlurDemo.self,
-        CornerCurveDemo.self
+        CornerCurveDemo.self,
+        SnapToClosestSheetSizeDemo.self
     ]
     
     override func viewDidLoad() {

--- a/Demos/ModalDemosViewController.swift
+++ b/Demos/ModalDemosViewController.swift
@@ -35,7 +35,8 @@ class ModalDemosViewController: UIViewController {
         BlurDemo.self,
         NestedSheetsDemo.self,
         RubberBandDemo.self,
-        CornerCurveDemo.self
+        CornerCurveDemo.self,
+        SnapToClosestSheetSizeDemo.self
     ].sorted(by: { $0.name < $1.name })
     
     override func viewDidLoad() {

--- a/FittedSheets.xcodeproj/project.pbxproj
+++ b/FittedSheets.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0D18902926C015F700CB6790 /* RubberBandDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D18902826C015F700CB6790 /* RubberBandDemo.swift */; };
 		42F0967527040EE7009774EA /* Compatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F0967427040EE7009774EA /* Compatible.swift */; };
 		46E78D7A2A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E78D792A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift */; };
+		93F1F3662D4C136B0028C7F4 /* SnapToClosestSheetSizeDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1F3652D4C136B0028C7F4 /* SnapToClosestSheetSizeDemo.swift */; };
 		C4E231E524E55E4E00D367FD /* BlurDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E231E424E55E4E00D367FD /* BlurDemo.swift */; };
 		D9C73C1F290B2BDF002590EC /* CornerCurveDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C73C1E290B2BDF002590EC /* CornerCurveDemo.swift */; };
 		F8034165212625DD00EAD717 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8034164212625DD00EAD717 /* AppDelegate.swift */; };
@@ -107,6 +108,7 @@
 		42F0967427040EE7009774EA /* Compatible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compatible.swift; sourceTree = "<group>"; };
 		46334410249C041700F334E5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		46E78D792A0B083F0021A5A3 /* PresentFullscreenModalCausesDidDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentFullscreenModalCausesDidDismiss.swift; sourceTree = "<group>"; };
+		93F1F3652D4C136B0028C7F4 /* SnapToClosestSheetSizeDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapToClosestSheetSizeDemo.swift; sourceTree = "<group>"; };
 		C4E231E424E55E4E00D367FD /* BlurDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurDemo.swift; sourceTree = "<group>"; };
 		D9C73C1E290B2BDF002590EC /* CornerCurveDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerCurveDemo.swift; sourceTree = "<group>"; };
 		F8034161212625DD00EAD717 /* Demos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demos.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -321,6 +323,7 @@
 				F8FAC6B325A38D570042A307 /* HorizontalPaddingDemo.swift */,
 				F8FAC6B825A3930F0042A307 /* MaxWidthDemo.swift */,
 				C4E231E424E55E4E00D367FD /* BlurDemo.swift */,
+				93F1F3652D4C136B0028C7F4 /* SnapToClosestSheetSizeDemo.swift */,
 			);
 			path = DemoControllers;
 			sourceTree = "<group>";
@@ -488,6 +491,7 @@
 				F83058DA25BF688300EE17E1 /* NoPullBarDemo.swift in Sources */,
 				F8A42B8C24DB1A67005DE55B /* InlineDemosViewController.swift in Sources */,
 				F8A42B6024D36DE3005DE55B /* MapDemo.swift in Sources */,
+				93F1F3662D4C136B0028C7F4 /* SnapToClosestSheetSizeDemo.swift in Sources */,
 				F8A42B8424DA022F005DE55B /* OnlyCloseWithButtonDemo.swift in Sources */,
 				0D18902926C015F700CB6790 /* RubberBandDemo.swift in Sources */,
 				F83058FD25BF777400EE17E1 /* SlideInAnimationBug118TagCell.swift in Sources */,
@@ -611,7 +615,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -665,7 +669,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -682,7 +686,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 478Z685Y37;
 				INFOPLIST_FILE = Demos/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -702,7 +706,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 478Z685Y37;
 				INFOPLIST_FILE = Demos/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -727,7 +731,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = FittedSheets/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -758,7 +762,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = FittedSheets/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FittedSheets/SheetOptions.swift
+++ b/FittedSheets/SheetOptions.swift
@@ -32,6 +32,11 @@ public struct SheetOptions {
     public var transitionVelocity: CGFloat = 0.8
     public var transitionOverflowType: TransitionOverflowType = .automatic
     
+    /// When enabled, the sheet will snap to the closest sheet size relative to the calculated
+    /// finalHeight in the panGesture, it will not take into account which direction the final
+    /// point at which the gesture ends (which the default behavior does)
+    public var shouldSnapToClosestSheetSize: Bool = false
+
     /// Default value 500, greater value will require more velocity to dismiss. Lesser values will do opposite.
     public var pullDismissThreshod: CGFloat = 500.0
     
@@ -59,7 +64,8 @@ public struct SheetOptions {
                 useInlineMode: Bool? = nil,
                 horizontalPadding: CGFloat? = nil,
                 maxWidth: CGFloat? = nil,
-                isRubberBandEnabled: Bool? = nil) {
+                isRubberBandEnabled: Bool? = nil,
+                shouldSnapToClosestSheetSize: Bool? = nil) {
         let defaultOptions = SheetOptions.default
         self.pullBarHeight = pullBarHeight ?? defaultOptions.pullBarHeight
         self.presentingViewCornerRadius = presentingViewCornerRadius ?? defaultOptions.presentingViewCornerRadius
@@ -72,6 +78,7 @@ public struct SheetOptions {
         let maxWidth = maxWidth ?? defaultOptions.maxWidth
         self.maxWidth = maxWidth == 0 ? nil : maxWidth
         self.isRubberBandEnabled = isRubberBandEnabled ?? false
+        self.shouldSnapToClosestSheetSize = shouldSnapToClosestSheetSize ?? false
     }
     
     @available(*, unavailable, message: "cornerRadius, minimumSpaceAbovePullBar, gripSize and gripColor are now properties on SheetViewController. Use them instead.")

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -362,7 +362,16 @@ public class SheetViewController: UIViewController {
         panGestureRecognizer.delegate = self
         self.panGestureRecognizer = panGestureRecognizer
     }
-    
+
+    /// Add an extra target for the main panGestureRecognizer, this gives users of
+    /// this library to observe the pan from outside the SheetViewController
+    /// - Parameters:
+    ///   - target: Target object for the GestureRecognizer
+    ///   - action: Selector to pass to the panGestureRecognizer
+    public func addAdditionalTargetForPanGestureRecognizer(target: Any, action: Selector) {
+        panGestureRecognizer.addTarget(target, action: action)
+    }
+
     @objc func panned(_ gesture: UIPanGestureRecognizer) {
         let point = gesture.translation(in: gesture.view?.superview)
         if gesture.state == .began {

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -148,7 +148,17 @@ public class SheetViewController: UIViewController {
     
     public var shouldDismiss: ((SheetViewController) -> Bool)?
     public var didDismiss: ((SheetViewController) -> Void)?
+
+    /// Closure to execute when the sheet size has completed changing (animation finished), and the new size is
+    /// different from the old size
     public var sizeChanged: ((SheetViewController, SheetSize, CGFloat) -> Void)?
+
+    /// Closure to execute before the sheet finishes changing size (Pan gesture ends, animation has not begun yet)
+    public var willAnimateToNewSize: ((SheetViewController, SheetSize, CGFloat) -> Void)?
+
+    /// Closure to execute when the sheet size has completed changing (animation finished), executes regardless of
+    /// what old size was
+    public var didAnimateToNewSize: ((SheetViewController, SheetSize, CGFloat) -> Void)?
     public var panGestureShouldBegin: ((UIPanGestureRecognizer) -> Bool?)?
     
     public private(set) var contentViewController: SheetContentViewController
@@ -478,6 +488,7 @@ public class SheetViewController: UIViewController {
                 self.currentSize = newSize
                 
                 let newContentHeight = self.height(for: newSize)
+                willAnimateToNewSize?(self, newSize, newContentHeight)
                 UIView.animate(
                     withDuration: animationDuration,
                     delay: 0,
@@ -492,6 +503,7 @@ public class SheetViewController: UIViewController {
                     self.view.layoutIfNeeded()
                 }, completion: { complete in
                     self.isPanning = false
+                    self.didAnimateToNewSize?(self, newSize, newContentHeight)
                     if previousSize != newSize {
                         self.sizeChanged?(self, newSize, newContentHeight)
                     }

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -615,13 +615,15 @@ public class SheetViewController: UIViewController {
         guard oldConstraintHeight != newHeight else {
             return
         }
-        
+
+        self.willAnimateToNewSize?(self, size, newHeight)
         if animated {
             UIView.animate(withDuration: duration, delay: 0, options: options, animations: { [weak self] in
                 guard let self = self, let constraint = self.contentViewHeightConstraint else { return }
                 constraint.constant = newHeight
                 self.view.layoutIfNeeded()
             }, completion: { _ in
+                self.didAnimateToNewSize?(self, size, newHeight)
                 if previousSize != size {
                     self.sizeChanged?(self, size, newHeight)
                 }
@@ -633,6 +635,8 @@ public class SheetViewController: UIViewController {
                 self.contentViewHeightConstraint?.constant = self.height(for: size)
                 self.contentViewController.view.layoutIfNeeded()
             }
+            self.didAnimateToNewSize?(self, size, newHeight)
+            self.sizeChanged?(self, size, newHeight)
             complete?()
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> I very much love this and appreciate this library, but need some new features in it. Although there are some fairly recent PRs in the original codebase (Sept 2024), there have been no major changes or feature additions in over a year. In my version ill be cleaning up a few things and adding some functionality. I hope the original author @gordontucker considers my PRs. Cheers!
+> I very much love and appreciate this library, but need some new features in it. Although there are some fairly recent PRs in the original codebase (Sept 2024), there have been no major changes or feature additions in over a year. In my version ill be cleaning up a few things and adding some functionality. I hope the original author @gordontucker considers my PRs. Cheers!
 
 # FittedSheets
 Bottom sheets for iOS

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+> I very much love this and appreciate this library, but need some new features in it. Although there are some fairly recent PRs in the original codebase (Sept 2024), there have been no major changes or feature additions in over a year. In my version ill be cleaning up a few things and adding some functionality. I hope the original author @gordontucker considers my PRs. Cheers!
+
 # FittedSheets
 Bottom sheets for iOS
 
 ![Bitrise Status](https://app.bitrise.io/app/13f283bd401bbe1c.svg?token=MGSP3TGNYPSgB5gWq4MEQg)
 
 Minimum requirement:  
-![iOSVersion](https://img.shields.io/badge/iOS-11-green.svg) 
+![iOSVersion](https://img.shields.io/badge/iOS-15-green.svg) 
 ![SwiftVersion](https://img.shields.io/badge/Swift-5-green.svg) 
 ![XcodeVersion](https://img.shields.io/badge/Xcode-11-green.svg)  
 


### PR DESCRIPTION
## PR summary
- Add support for snapping to closest `SheetSize` based on the FinalHeight calculated in the `panned(_ gesture: UIPanGestureRecognizer) function`
- Add demo screen for new functionality

## Justification 

- Currently the `SheetSize` snapping logic depends on which direction you have pulled the view from the start of your gesture
- The above original logic causes issues when creating an experience where you may want the sheet to stay near the closest snap point if the user moved it only a bit, and then lets go without much velocity
- The new snapping logic allows the sheet to snap to the nearest SheetSize, but it also takes into account velocity of the pan, this combination feels more natural in many use cases for a sheet, and is closer to the default behavior of an iOS modal

Video **WITH** setting enabled:

https://github.com/user-attachments/assets/011e7727-f7ac-4b61-a2d0-ed2cbd85e080

Video **WITHOUT** new setting enabled:

https://github.com/user-attachments/assets/c5a2f254-01e3-4204-ba43-06e2bfdef08c
